### PR TITLE
Fix dependency on rstan

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Suggests:
     knitr,
     roxygen2,
     rmarkdown,
+    rstan,
     testthat (>= 3.0.0)
 LinkingTo: 
     Rcpp (>= 0.12.0),


### PR DESCRIPTION
Your `src/Makevars` file has `utils::packageVersion('rstan')` however the dependency on this package is not declared.

Therefore the build fails on r-universe: https://github.com/r-universe/cran/actions/runs/14430397423/job/40470523688

```
  Error in utils::packageVersion("rstan") : 
    there is no package called ‘rstan’
  Calls: cat -> ifelse -> <Anonymous>
  Execution halted
...
```